### PR TITLE
fix: k8s CA CERT invalid w/ bash

### DIFF
--- a/templates/linux-mac-common.html
+++ b/templates/linux-mac-common.html
@@ -48,7 +48,7 @@
 
 {{ end }} kubectl config set-cluster {{ .ClusterName }} \
   {{- if .K8sCaPem }}
-  --certificate-authority <(echo -n $K8S_CA_CERT) \
+  --certificate-authority <(echo -n "$K8S_CA_CERT") \
   --embed-certs=true \
   {{- end }}
   --server={{ .K8sMasterURI }}</code></pre>


### PR DESCRIPTION
The line breaks were being stripped from multiline CA CERT variable.