### PR TITLE
feat: cleanup cluster credentials/user (if any)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ bin
 dex-k8s-authenticator
 !charts/dex-k8s-authenticator
 .idea
+examples/dex.db

--- a/templates/linux-mac-common.html
+++ b/templates/linux-mac-common.html
@@ -58,19 +58,22 @@
     <button class="btn" style="float:right" data-clipboard-snippet="">
       <img class="clippy" width="13" src="{{ .Web_Path_Prefix }}static/clippy.svg" alt=""/>
     </button>
-    <pre><code>kubectl config set-credentials {{ .Username }}-{{ .ClusterName }} \
-      --exec-api-version=client.authentication.k8s.io/v1beta1 \
-      --exec-command=kubectl \
-      --exec-arg=oidc-login \
-      --exec-arg=get-token \
-      --exec-arg=--listen-address=127.0.0.1:18000 \
-      --exec-arg=--oidc-issuer-url={{ .Issuer }} \
-      --exec-arg=--oidc-client-id={{ .ClientID }} \
+    <pre><code># Delete existing user (if it exists)
+kubectl config delete-user {{ .Username }}-{{ .ClusterName }} || true
+
+kubectl config set-credentials {{ .Username }}-{{ .ClusterName }} \
+    --exec-api-version=client.authentication.k8s.io/v1beta1 \
+    --exec-command=kubectl \
+    --exec-arg=oidc-login \
+    --exec-arg=get-token \
+    --exec-arg=--listen-address=127.0.0.1:18000 \
+    --exec-arg=--oidc-issuer-url={{ .Issuer }} \
+    --exec-arg=--oidc-client-id={{ .ClientID }} \
   {{- if .ClientSecret }}
-      --exec-arg=--oidc-client-secret={{ .ClientSecret }} \
+    --exec-arg=--oidc-client-secret={{ .ClientSecret }} \
   {{- end }}
-      --exec-arg=--oidc-extra-scope=email \
-      --exec-arg=--oidc-extra-scope=groups</code></pre>
+    --exec-arg=--oidc-extra-scope=email \
+    --exec-arg=--oidc-extra-scope=groups</code></pre>
   </div>
 
   <div class="command">


### PR DESCRIPTION
This is to help streamline migration from the old instructions, so users don't end up with conflicting user configurations.

It looks like this:
![image](https://github.com/getditto/dex-k8s-authenticator/assets/8053182/ff9f6385-2f34-4294-be12-9ac109ea3e50)
